### PR TITLE
fix: skip urls that are already https

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
 'use strict';
 
 const HTTPS = 'https://';
+const httpsRe = /(^https:\/\/)/;
 const protocolRe = /(^http:\/\/)|(^\/\/)/;
 const convertToHttps = url => url.replace(protocolRe, HTTPS);
 
 module.exports = input => {
   if (typeof input !== 'string') {
     throw new TypeError(`Expected a string, got ${typeof input}`);
+  }
+
+  if (input.match(httpsRe)) {
+    return input;
   }
 
   return input.match(protocolRe) ? convertToHttps(input) : `${HTTPS}${input}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "to-https",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Convert (almost) any url to https.",
 	"license": "MIT",
 	"repository": "github:chrisvogt/to-https",

--- a/test.js
+++ b/test.js
@@ -8,6 +8,10 @@ test('input validation', t => {
   t.is(err.message, 'Expected a string, got number');
 });
 
+test('https urls are returned as-is', t => {
+  t.is(toHttps('https://www.chrisvogt.me'), 'https://www.chrisvogt.me');
+});
+
 test('converting http urls to https', t => {
   t.is(toHttps('http://www.chrisvogt.me'), 'https://www.chrisvogt.me');
 });


### PR DESCRIPTION
This package has been prepending "https://" to URLs that already using https, resulting in the failed test below. This PR fixes that by returning the unmodified input if it is already https.

```
  1 test failed

  https urls are returned as-is

  /Users/chrisvogt/Dev/node-packages/to-https/test.js:12

   11: test('https urls are returned as-is', t => {
   12:   t.is(toHttps('https://www.chrisvogt.me'), 'https://www.chrisvogt.me'…
   13: });

  Difference:

  - 'https://https://www.chrisvogt.me'
  + 'https://www.chrisvogt.me'
```